### PR TITLE
Remove FFImageLoading and update UI components

### DIFF
--- a/EpubReader/EpubReader.csproj
+++ b/EpubReader/EpubReader.csproj
@@ -76,7 +76,6 @@
    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
     <PackageReference Include="Microsoft.Maui.Graphics" Version="*" />
     <PackageReference Include="Microsoft.Maui.Graphics.Skia" Version="*" />
-    <PackageReference Include="FFImageLoading.Maui" Version="1.2.7" />
     <PackageReference Include="VersOne.Epub" Version="3.3.3" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="*" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.3" />
@@ -89,11 +88,6 @@
 		<PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
 		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.11" />
     <PackageReference Include="SQLite.Net.Extensions" Version="3.0.0" />
-    <PackageReference Include="MimeTypes" Version="2.5.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    
 	</ItemGroup>
   
   <ItemGroup Condition="$(TargetFramework.Contains('-android'))">

--- a/EpubReader/MauiProgram.cs
+++ b/EpubReader/MauiProgram.cs
@@ -2,17 +2,16 @@
 using CommunityToolkit.Maui.Storage;
 using EpubReader.Database;
 using EpubReader.Interfaces;
+using EpubReader.Util;
 using EpubReader.ViewModels;
 using EpubReader.Views;
-using FFImageLoading.Maui;
 using MetroLog;
 using MetroLog.Operators;
 using MetroLog.Targets;
+using Microsoft.Extensions.Logging;
 using Syncfusion.Maui.Toolkit.Hosting;
 using LoggerFactory = MetroLog.LoggerFactory;
 using LogLevel = MetroLog.LogLevel;
-using Microsoft.Extensions.Logging;
-using EpubReader.Util;
 
 [assembly: XamlCompilation(XamlCompilationOptions.Compile)]
 
@@ -27,7 +26,6 @@ public static class MauiProgram
 			fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
 			fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
 		})
-		.UseFFImageLoading()
 		.UseMauiCommunityToolkit(options =>
 		{
 			options.SetShouldEnableSnackbarOnWindows(true);

--- a/EpubReader/ViewModels/SettingsPageViewModel.cs
+++ b/EpubReader/ViewModels/SettingsPageViewModel.cs
@@ -13,7 +13,6 @@ public partial class SettingsPageViewModel : BaseViewModel
 		new EpubFonts { FontFamily = "Tahoma" },
 		new EpubFonts { FontFamily = "Trebuchet MS" },
 		new EpubFonts { FontFamily = "Comic Sans MS" },
-		new EpubFonts { FontFamily = "Lucida Sans Unicode" },
 		new EpubFonts { FontFamily = "Helvetica" }
 ];
 	readonly List<ColorScheme> colorSchemes =
@@ -21,7 +20,6 @@ public partial class SettingsPageViewModel : BaseViewModel
 			new ColorScheme() { Name = "Light", BackgroundColor = "#FFFFFF" , TextColor = "#000000"},
 			new ColorScheme() { Name = "Dark", BackgroundColor = "#121212", TextColor = "#E1E1E1" },
 			new ColorScheme() { Name = "Sepia", BackgroundColor = "#f4ecd8", TextColor = "#5b4636" },
-			new ColorScheme() { Name = "Forest", BackgroundColor = "#e0f2e9", TextColor = "#2e4d38" },
 			new ColorScheme() { Name = "Ocean", BackgroundColor = "#e0f7fa", TextColor = "#01579b" },
 			new ColorScheme() { Name = "Sand", BackgroundColor = "#f5deb3", TextColor = "#000000" },
 			new ColorScheme() { Name = "Charcoal", BackgroundColor = "#36454f", TextColor = "#dcdcdc" },

--- a/EpubReader/Views/BookPage.xaml
+++ b/EpubReader/Views/BookPage.xaml
@@ -24,57 +24,61 @@
             Order="Primary" />
     </ContentPage.ToolbarItems>
 
-    <Grid x:Name="Grid" BackgroundColor="{AppThemeBinding Light={StaticResource Blue200Accent}, Dark={StaticResource AppBackgroundDarkColor}}">
-        <Grid.GestureRecognizers>
-            <OnPlatform x:TypeArguments="TapGestureRecognizer">
-                <On Platform="MacCatalyst">
-                    <TapGestureRecognizer
-                        BindingContext="{Binding Path=BindingContext, Source={x:Reference CurrentPage}, x:DataType=ContentPage}"
-                        Command="{Binding PressCommand}"
-                        NumberOfTapsRequired="2" />
-                </On>
-                <On Platform="WinUI">
-                    <TapGestureRecognizer
-                        BindingContext="{Binding Path=BindingContext, Source={x:Reference CurrentPage}, x:DataType=ContentPage}"
-                        Command="{Binding PressCommand}"
-                        NumberOfTapsRequired="2" />
-                </On>
-            </OnPlatform>
-        </Grid.GestureRecognizers>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="*" />
-            <RowDefinition Height="auto" />
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
-        <WebView
-            x:Name="EpubText"
-            Grid.Row="0"
-            Navigated="webView_Navigated"
-            Navigating="webView_Navigating"
-            Scale="1"
-            Source="{Binding Source}">
-            <WebView.GestureRecognizers>
-                <OnPlatform x:TypeArguments="SwipeGestureRecognizer">
-                    <On Platform="Android">
-                        <SwipeGestureRecognizer Direction="Up" Swiped="SwipeGestureRecognizer_Swiped" />
-                    </On>
-                    <On Platform="IOS">
-                        <SwipeGestureRecognizer Direction="Up" Swiped="SwipeGestureRecognizer_Swiped" />
-                    </On>
-                </OnPlatform>
-            </WebView.GestureRecognizers>
-        </WebView>
+    <shimmer:SfShimmer x:Name="Shimmer" AnimationDuration="3000">
+        <shimmer:SfShimmer.Content>
+            <Grid x:Name="Grid" BackgroundColor="{AppThemeBinding Light={StaticResource Blue200Accent}, Dark={StaticResource AppBackgroundDarkColor}}">
+                <Grid.GestureRecognizers>
+                    <OnPlatform x:TypeArguments="TapGestureRecognizer">
+                        <On Platform="MacCatalyst">
+                            <TapGestureRecognizer
+                                BindingContext="{Binding Path=BindingContext, Source={x:Reference CurrentPage}, x:DataType=ContentPage}"
+                                Command="{Binding PressCommand}"
+                                NumberOfTapsRequired="2" />
+                        </On>
+                        <On Platform="WinUI">
+                            <TapGestureRecognizer
+                                BindingContext="{Binding Path=BindingContext, Source={x:Reference CurrentPage}, x:DataType=ContentPage}"
+                                Command="{Binding PressCommand}"
+                                NumberOfTapsRequired="2" />
+                        </On>
+                    </OnPlatform>
+                </Grid.GestureRecognizers>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="auto" />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <WebView
+                    x:Name="EpubText"
+                    Grid.Row="0"
+                    Navigated="webView_Navigated"
+                    Navigating="webView_Navigating"
+                    Scale="1"
+                    Source="{Binding Source}">
+                    <WebView.GestureRecognizers>
+                        <OnPlatform x:TypeArguments="SwipeGestureRecognizer">
+                            <On Platform="Android">
+                                <SwipeGestureRecognizer Direction="Up" Swiped="SwipeGestureRecognizer_Swiped" />
+                            </On>
+                            <On Platform="IOS">
+                                <SwipeGestureRecognizer Direction="Up" Swiped="SwipeGestureRecognizer_Swiped" />
+                            </On>
+                        </OnPlatform>
+                    </WebView.GestureRecognizers>
+                </WebView>
 
-        <Label
-            x:Name="PageLabel"
-            Grid.Row="1"
-            FontSize="20"
-            HorizontalOptions="Center"
-            IsVisible="{OnPlatform WinUI=true,
-                                   MacCatalyst=true,
-                                   iOS={Binding IsNavMenuVisible},
-                                   Android={Binding IsNavMenuVisible}}" />
-    </Grid>
+                <Label
+                    x:Name="PageLabel"
+                    Grid.Row="1"
+                    FontSize="20"
+                    HorizontalOptions="Center"
+                    IsVisible="{OnPlatform WinUI=true,
+                                           MacCatalyst=true,
+                                           iOS={Binding IsNavMenuVisible},
+                                           Android={Binding IsNavMenuVisible}}" />
+            </Grid>
+        </shimmer:SfShimmer.Content>
+    </shimmer:SfShimmer>
 </ContentPage>

--- a/EpubReader/Views/BookPage.xaml.cs
+++ b/EpubReader/Views/BookPage.xaml.cs
@@ -170,6 +170,7 @@ public partial class BookPage : ContentPage, IDisposable
 		loadIndex = false;
 		var pageToLoad = $"https://demo/" + Path.GetFileName(book.Chapters[book.CurrentChapter].FileName);
 		await EpubText.EvaluateJavaScriptAsync($"loadPage('{pageToLoad}');");
+		Shimmer.IsActive = false;
 	}
 
 	async void webView_Navigating(object sender, WebNavigatingEventArgs e)

--- a/EpubReader/Views/LibraryPage.xaml
+++ b/EpubReader/Views/LibraryPage.xaml
@@ -4,7 +4,6 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:Models="clr-namespace:EpubReader.Models"
-    xmlns:ffimageloading="clr-namespace:FFImageLoading.Maui;assembly=FFImageLoading.Maui"
     xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
     xmlns:viewModels="clr-namespace:EpubReader.ViewModels"
     x:Name="CurrentPage"
@@ -71,12 +70,10 @@
                                 Style="{StaticResource EbookLabelText}"
                                 Text="{Binding Title}" />
 
-                            <ffimageloading:CachedImage
+                            <Image
                                 Grid.Row="1"
                                 Margin="8,4,8,8"
                                 Aspect="AspectFit"
-                                CacheDuration="30"
-                                DownsampleToViewSize="True"
                                 HeightRequest="{StaticResource CardHeight}"
                                 HorizontalOptions="Center"
                                 Source="{Binding CoverImage, Mode=OneWay, Converter={StaticResource ByteArrayToImageSourceConverter}}">
@@ -91,10 +88,10 @@
                                     </MenuFlyout>
                                 </FlyoutBase.ContextFlyout>
 
-                                <ffimageloading:CachedImage.GestureRecognizers>
+                                <Image.GestureRecognizers>
                                     <TapGestureRecognizer Command="{Binding GotoBookPageCommand, x:DataType=viewModels:LibraryViewModel, Source={RelativeSource AncestorType={x:Type viewModels:LibraryViewModel}}}" CommandParameter="{Binding .}" />
-                                </ffimageloading:CachedImage.GestureRecognizers>
-                            </ffimageloading:CachedImage>
+                                </Image.GestureRecognizers>
+                            </Image>
 
                         </Grid>
                     </Border>


### PR DESCRIPTION
- Eliminated `FFImageLoading.Maui` package and related code.
- Removed `MimeTypes` package reference and properties.
- Updated `MauiProgram` to remove FFImageLoading usage.
- Cleaned up font and color scheme entries in `SettingsPageViewModel`.
- Replaced `Grid` with `shimmer:SfShimmer` in `BookPage.xaml`.
- Deactivated `Shimmer` effect in `webView_Navigating`.
- Updated `LibraryPage` to use standard `Image` control instead of `ffimageloading:CachedImage`.