### PR TITLE
Add support for multiple columns in settings

### DIFF
--- a/EpubReader/Models/Settings.cs
+++ b/EpubReader/Models/Settings.cs
@@ -18,4 +18,6 @@ public class Settings
 	public string TextColor { get; set; } = string.Empty;
 	[Column("ColorScheme")]
 	public string ColorScheme { get; set; } = string.Empty;
+	[Column("SupportMultipleColumns")]
+	public bool SupportMultipleColumns { get; set; } = false;
 }

--- a/EpubReader/Util/WebViewHelper.cs
+++ b/EpubReader/Util/WebViewHelper.cs
@@ -20,7 +20,14 @@ public partial class WebViewHelper(WebView handler)
 		await webView.EvaluateJavaScriptAsync("setReadiumProperty('--USER__fontOverride', 'readium-font-on')");
 		await webView.EvaluateJavaScriptAsync($"setReadiumProperty('--USER__fontFamily', '{settings.FontFamily}')");
 		await webView.EvaluateJavaScriptAsync($"setReadiumProperty('--USER__fontSize','{settings.FontSize * 10}%')");
-		await webView.EvaluateJavaScriptAsync($"setReadiumProperty('--USER__colCount','1')");
+		if(settings.SupportMultipleColumns)
+		{
+			await webView.EvaluateJavaScriptAsync($"setReadiumProperty('--USER__colCount','2')");
+		}
+		else
+		{
+			await webView.EvaluateJavaScriptAsync($"setReadiumProperty('--USER__colCount','1')");
+		}
 		await webView.EvaluateJavaScriptAsync("gotoEnd();");
 		await webView.EvaluateJavaScriptAsync("getPageCount()");
 	}

--- a/EpubReader/Views/BookPage.xaml.cs
+++ b/EpubReader/Views/BookPage.xaml.cs
@@ -91,7 +91,6 @@ public partial class BookPage : ContentPage, IDisposable
 
 	async void webView_Navigated(object? sender, WebNavigatedEventArgs e)
 	{
-		System.Diagnostics.Debug.WriteLine($"Navigated event.");
 		ArgumentNullException.ThrowIfNull(book);
 		if (!loadIndex)
 		{
@@ -104,7 +103,6 @@ public partial class BookPage : ContentPage, IDisposable
 
 	async void webView_Navigating(object? sender, WebNavigatingEventArgs e)
 	{
-		System.Diagnostics.Debug.WriteLine($"Navigating event.");
 		var urlParts = e.Url.Split('.');
 		ArgumentNullException.ThrowIfNull(book);
 		if (!urlParts[0].Contains("runcsharp", StringComparison.CurrentCultureIgnoreCase))

--- a/EpubReader/Views/SettingsPage.xaml
+++ b/EpubReader/Views/SettingsPage.xaml
@@ -89,11 +89,18 @@
             SelectedIndexChanged="ThemePicker_SelectedIndexChanged" />
 
         <Button
-            Grid.Row="10"
+            Grid.Row="9"
             Clicked="RemoveAllSettings"
             HeightRequest="45"
             Text="Reset"
             WidthRequest="120" />
+        <Button
+            IsVisible="{OnPlatform WinUI=true, Default=false}"
+            x:Name="ButtonColumn"
+            Grid.Row="11"
+            Clicked="ToggleMultipleColumns"
+            HeightRequest="45"
+            WidthRequest="250"/>
     </Grid>
 
 </mct:Popup>

--- a/EpubReader/Views/SettingsPage.xaml.cs
+++ b/EpubReader/Views/SettingsPage.xaml.cs
@@ -20,6 +20,7 @@ public partial class SettingsPage : Popup
 		this.db = db;
 		settings = db.GetSettings() ?? new();
 		FontSizeSlider.Value = settings.FontSize;
+		ButtonColumn.Text = settings.SupportMultipleColumns ? "Disable Multiple Columns" : "Enable Multiple Columns";
 		FontPicker.SelectedItem = ((SettingsPageViewModel)BindingContext).Fonts.Find(x => x.FontFamily == settings.FontFamily);
 		ThemePicker.SelectedItem = ((SettingsPageViewModel)BindingContext).ColorSchemes.Find(x => x.Name == settings.ColorScheme);
 	}
@@ -75,5 +76,13 @@ public partial class SettingsPage : Popup
 		logger.Info($"Chaging Font to: {font.FontFamily}");
 		db.SaveSettings(settings);
 		WeakReferenceMessenger.Default.Send(new SettingsMessage(true));
+	}
+
+	void ToggleMultipleColumns(object sender, EventArgs e)
+	{
+		settings.SupportMultipleColumns = !settings.SupportMultipleColumns;
+		db.SaveSettings(settings);
+		WeakReferenceMessenger.Default.Send(new SettingsMessage(true));
+		ButtonColumn.Text = settings.SupportMultipleColumns ? "Disable Multiple Columns" : "Enable Multiple Columns";
 	}
 }


### PR DESCRIPTION
Add support for multiple columns in settings

- Introduced `SupportMultipleColumns` property in the `Settings` class.
- Updated `WebViewHelper` to adjust column count based on the new property.
- Removed debug logging from `webView_Navigated` and `webView_Navigating` in `BookPage`.
- Enhanced `SettingsPage` XAML with a button to toggle multiple columns, with platform-specific visibility.
- Implemented `ToggleMultipleColumns` method in `SettingsPage` to manage the setting and update button text.