### PR TITLE
Update color scheme hex codes to uppercase

### DIFF
--- a/EpubReader/ViewModels/SettingsPageViewModel.cs
+++ b/EpubReader/ViewModels/SettingsPageViewModel.cs
@@ -25,10 +25,10 @@ public partial class SettingsPageViewModel : BaseViewModel
 		[
 			new ColorScheme() { Name = "Light", BackgroundColor = "#FFFFFF" , TextColor = "#000000"},
 			new ColorScheme() { Name = "Dark", BackgroundColor = "#121212", TextColor = "#E1E1E1" },
-			new ColorScheme() { Name = "Sepia", BackgroundColor = "#f4ecd8", TextColor = "#5b4636" },
-			new ColorScheme() { Name = "Ocean", BackgroundColor = "#e0f7fa", TextColor = "#01579b" },
+			new ColorScheme() { Name = "Sepia", BackgroundColor = "#f4ecd8", TextColor = "#5B4636" },
+			new ColorScheme() { Name = "Ocean", BackgroundColor = "#e0f7fa", TextColor = "#01579B" },
 			new ColorScheme() { Name = "Sand", BackgroundColor = "#f5deb3", TextColor = "#000000" },
-			new ColorScheme() { Name = "Charcoal", BackgroundColor = "#36454f", TextColor = "#dcdcdc" },
+			new ColorScheme() { Name = "Charcoal", BackgroundColor = "#36454f", TextColor = "#DCDCDC" },
 			new ColorScheme() { Name = "Vintage", BackgroundColor = "#f5f5dc", TextColor = "#000000" }
 		];
 


### PR DESCRIPTION
Modified the `colorSchemes` list in the `SettingsPageViewModel` class. Updated the `TextColor` values for the "Sepia", "Ocean", and "Charcoal" color schemes to use uppercase letters in their hexadecimal color codes for consistency.