### PR TITLE
Fix chapter navigation Bug

### DIFF
--- a/EpubReader/Views/BookPage.xaml.cs
+++ b/EpubReader/Views/BookPage.xaml.cs
@@ -317,6 +317,7 @@ public partial class BookPage : ContentPage
 				Dispatcher.Dispatch(async () =>
 				{
 					book.CurrentChapter = index;
+					book.CurrentPage = 0; // Reset current page to 0 when changing chapter
 					await db.UpdateBookMark(book);
 					var file = Path.GetFileName(book.Chapters[book.CurrentChapter].FileName);
 					await webView.EvaluateJavaScriptAsync($"loadPage(\"{file}\")");
@@ -342,6 +343,7 @@ public partial class BookPage : ContentPage
 				Dispatcher.Dispatch(async () =>
 				{
 					book.CurrentChapter = index;
+					book.CurrentPage = 0; // Reset current page when changing chapter
 					await db.UpdateBookMark(book);
 					var file = Path.GetFileName(book.Chapters[book.CurrentChapter].FileName);
 					await webView.EvaluateJavaScriptAsync($"loadPage(\"{file}\")");


### PR DESCRIPTION
#### PR Classification
Code enhancement to improve user experience when changing chapters in the book.

#### PR Summary
This pull request adds functionality to reset the `CurrentPage` to 0 when the `CurrentChapter` is changed, ensuring users start from the first page of the new chapter. 
- BookPage.xaml.cs: Added line to reset `CurrentPage` to 0 when changing `CurrentChapter`using menu from app.
